### PR TITLE
Several small fixes

### DIFF
--- a/disco.go
+++ b/disco.go
@@ -19,11 +19,9 @@ var (
 	fCommunity          = flag.String("community", "", "The SNMP community string for the switch.")
 	fDataDir            = flag.String("datadir", "/var/spool/disco", "Base directory where metrics files will be written.")
 	fHostname           = flag.String("hostname", "", "The FQDN of the node.")
-	fListenAddress      = flag.String("listen-address", ":8888", "Address to listen on for telemetry.")
 	fMetricsFile        = flag.String("metrics", "", "Path to YAML file defining metrics to scrape.")
 	fWriteInterval      = flag.Duration("write-interval", 300*time.Second, "Interval to write out JSON files e.g, 300s, 10m.")
 	fTarget             = flag.String("target", "", "Switch FQDN to scrape metrics from.")
-	logFatal            = log.Fatal
 	mainCtx, mainCancel = context.WithCancel(context.Background())
 )
 

--- a/disco.go
+++ b/disco.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/m-lab/disco/config"
@@ -40,7 +41,7 @@ func main() {
 	goSNMP := &gosnmp.GoSNMP{
 		Target:    *fTarget,
 		Port:      uint16(161),
-		Community: *fCommunity,
+		Community: strings.TrimSpace(*fCommunity),
 		Version:   gosnmp.Version2c,
 		Timeout:   time.Duration(5) * time.Second,
 		Retries:   1,

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -85,6 +85,22 @@ func mustGetIfaces(client snmp.Client, machine string) map[string]map[string]str
 		}
 	}
 
+	// Fail if any machine information was not found.
+	if ifaces["machine"]["iface"] == "" {
+		log.Fatalf("Failed to find logical iface number for machine: %v", machine)
+	}
+	if ifaces["machine"]["ifDescr"] == "" {
+		log.Fatalf("Failed to find ifDescr for machine logical iface: %v", ifaces["machine"]["iface"])
+	}
+
+	// Fail if any uplink information was not found.
+	if ifaces["uplink"]["iface"] == "" {
+		log.Fatal("Failed to find logical iface number for uplink")
+	}
+	if ifaces["uplink"]["ifDescr"] == "" {
+		log.Fatalf("Failed to find ifDescr for uplink logical iface: %v", ifaces["uplink"]["iface"])
+	}
+
 	return ifaces
 }
 


### PR DESCRIPTION
* Removes two unused flags.
* Trims whitespace from either side of the `-community` flag. The flag can be passed in as an env variable. In k8s the env variable comes from a secret, and the secret is originally a file... maybe with a newline.
* Adds some extra failure checking to `mustGetIfaces()` to fail if any bit of data is not found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/5)
<!-- Reviewable:end -->
