### PR TITLE
Attempts to construct a target switch name based on the node name

### DIFF
--- a/disco.go
+++ b/disco.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -36,6 +37,12 @@ func main() {
 
 	if len(*fHostname) <= 0 {
 		log.Fatal("Node's FQDN must be passed as an arg or env variable.")
+	}
+
+	// If the -target flag is empty, then attempt to construct it using the hostname.
+	if len(*fTarget) <= 0 {
+		h := *fHostname
+		*fTarget = fmt.Sprintf("s1-%s.measurement-lab.org", h[6:11])
 	}
 
 	goSNMP := &gosnmp.GoSNMP{


### PR DESCRIPTION
If the `-target` flag was not passed, then try to construct a suitable target based on the hostname.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/7)
<!-- Reviewable:end -->
