### PR TITLE
Sets end time in filename to accurately reflect last data collection time

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -35,7 +35,7 @@ func MustMarshalJSON(m Model) []byte {
 	return data
 }
 
-// GetPath returns a relative filesystem path where an archive should be written.
+// GetPath returns a filesystem path where an archive should be written.
 func GetPath(start time.Time, end time.Time, dataDir string, hostname string) string {
 	// The directory path where the archive should be written.
 	dirs := fmt.Sprintf("%v/%v", end.Format("2006/01/02"), hostname)

--- a/disco.go
+++ b/disco.go
@@ -100,13 +100,13 @@ func main() {
 		case <-writeTicker.C:
 			start := metrics.IntervalStart
 			metrics.IntervalStart = time.Now()
-			metrics.Write(start, time.Now(), *fDataDir)
+			metrics.Write(start, *fDataDir)
 		case <-collectTicker.C:
 			metrics.CollectStart = time.Now()
 			metrics.Collect(client, config)
 		case <-sigterm:
 			start := metrics.IntervalStart
-			metrics.Write(start, time.Now(), *fDataDir)
+			metrics.Write(start, *fDataDir)
 			mainCancel()
 			return
 		}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -227,6 +227,11 @@ func (metrics *Metrics) Write(start time.Time, dataDir string) {
 		// the last value assigned to it. The final timestamp for every metric
 		// should be the same. This seemed better than any alternative trying to
 		// determine the last element in the range and only assigning once.
+		//
+		// NOTE: This usage is selecting the final timestamp of an arbitrary map
+		// element, which works because every timestamp for a given collection
+		// is necessarily the same. But please note that if this changes in the
+		// future that this method will no longer be reliable.
 		endTimeUnix = metrics.oids[oid].interval.Samples[len(metrics.oids[oid].interval.Samples)-1].Timestamp
 		// Reset the samples to an empty slice of archive.Sample for the next
 		// interval.

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -378,6 +378,7 @@ func Test_Write(t *testing.T) {
 		run: 1,
 	}
 	m := New(s1, c, target, hostname)
+	m.CollectStart = time.Now()
 	m.Collect(s1, c)
 
 	s2 := &mockSwitchClient{
@@ -391,7 +392,7 @@ func Test_Write(t *testing.T) {
 	archivePath := archive.GetPath(start, end, "/tmp/disco", hostname)
 	dirPath := path.Dir(archivePath)
 
-	m.Write(start, end, "/tmp/disco")
+	m.Write(start, "/tmp/disco")
 	defer os.RemoveAll("/tmp/disco")
 
 	a, err := ioutil.ReadDir(dirPath)


### PR DESCRIPTION
Currently, the default interval for writing collected data is 5m. When files get written they take a form somewhat like:

```
<time>-to-<time>.jsonl
```

The final time reflects the end of the interval, not the last actual collection time. For example, if we are collecting from 08:15:00 to 08:20:00, the file name would include 08:20:00 as the end time, yet the last sample included in the file was actually from 08:19:50. The next file to be written will be the one to actually contain data collected at 08:20:00.

This PR attempts to address that confusion by naming the file such that the ending time accurately reflects the last collection time, not just the end of the interval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/10)
<!-- Reviewable:end -->
