### PR TITLE
Adds a comment warning about changing a variable.

### DIFF
--- a/disco.go
+++ b/disco.go
@@ -102,6 +102,10 @@ func main() {
 			metrics.IntervalStart = time.Now()
 			metrics.Write(start, *fDataDir)
 		case <-collectTicker.C:
+			// NOTE: The value of CollectStart is used as the sample Timestamp
+			// for all metrics from a given collection. The current code relies
+			// this timestamp always being the same, if this changes, then the
+			// code in metrics.Collect() will need to be modified.
 			metrics.CollectStart = time.Now()
 			metrics.Collect(client, config)
 		case <-sigterm:

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -190,6 +190,11 @@ func (metrics *Metrics) Collect(client snmp.Client, config config.Config) error 
 		metrics.oids[oid].interval.Samples = append(
 			metrics.oids[oid].interval.Samples,
 			archive.Sample{
+				// NOTE: The value of CollectStart is assigned to every metric
+				// in a given collection, and this fact is taken advantage of in
+				// metrics.Write(). If we start assigning possibly unique
+				// timestamps to each sample metric, then the code in Write()
+				// will need to be modified.
 				Timestamp:    metrics.CollectStart.Unix(),
 				CollectStart: collectStart.UnixNano(),
 				CollectEnd:   collectEnd.UnixNano(),


### PR DESCRIPTION
We currently rely on all sample timestamps for given collection to be the same. This PR adds a comment warning not to change how the timestamp variable is assigned without also modifying the code that relies on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/11)
<!-- Reviewable:end -->
