### PR TITLE
Expect a string from gosnmp PDUs of type OctetString

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -67,8 +67,7 @@ func mustGetIfaces(client snmp.Client, machine string) map[string]map[string]str
 		oidParts := strings.Split(pdu.Name, ".")
 		iface := oidParts[len(oidParts)-1]
 
-		b := pdu.Value.([]byte)
-		val := strings.TrimSpace(string(b))
+		val := strings.TrimSpace(pdu.Value.(string))
 		if val == machine {
 			ifDescrOid := createOID(ifDescrOidStub, iface)
 			oidMap, err := getOidsString(client, []string{ifDescrOid})
@@ -110,7 +109,7 @@ func getOidsString(client snmp.Client, oids []string) (map[string]string, error)
 	oidMap := make(map[string]string)
 	result, err := client.Get(oids)
 	for _, pdu := range result.Variables {
-		oidMap[pdu.Name] = string(pdu.Value.([]byte))
+		oidMap[pdu.Name] = pdu.Value.(string)
 	}
 	return oidMap, err
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -56,7 +56,7 @@ var snmpPacketMachine = gosnmp.SnmpPacket{
 		{
 			Name:  ifDescrMachineOID,
 			Type:  gosnmp.OctetString,
-			Value: []byte("xe-0/0/12"),
+			Value: "xe-0/0/12",
 		},
 	},
 }
@@ -66,7 +66,7 @@ var snmpPacketUplink = gosnmp.SnmpPacket{
 		{
 			Name:  ifDescrUplinkOID,
 			Type:  gosnmp.OctetString,
-			Value: []byte("xe-0/0/45"),
+			Value: "xe-0/0/45",
 		},
 	},
 }
@@ -141,12 +141,12 @@ func (m *mockSwitchClient) BulkWalkAll(rootOid string) (results []gosnmp.SnmpPDU
 		{
 			Name:  ifDescrMachineOID,
 			Type:  gosnmp.OctetString,
-			Value: []byte("mlab2"),
+			Value: "mlab2",
 		},
 		{
 			Name:  ifDescrUplinkOID,
 			Type:  gosnmp.OctetString,
-			Value: []byte("uplink-10g"),
+			Value: "uplink-10g",
 		},
 	}, nil
 }


### PR DESCRIPTION
It used to be that gosnmp would return a byte slice for PDUs of type `OctetString`.  [Last June that changed](https://github.com/soniah/gosnmp/commit/e59037318761e1f659613681705ca950bde396f9#diff-f802b6e7d313bfb1c0ba508f60f44fb1R103), and it now returns type string for PDUs of type `OctetString`, which I suppose makes more sense. This PR updates the disco code to expect type string in these cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/12)
<!-- Reviewable:end -->
