### PR TITLE
Calculates filenames based on actual timestamps inside the files

### DIFF
--- a/disco.go
+++ b/disco.go
@@ -98,9 +98,7 @@ func main() {
 		case <-mainCtx.Done():
 			return
 		case <-writeTicker.C:
-			start := metrics.IntervalStart
-			metrics.IntervalStart = time.Now()
-			metrics.Write(start, *fDataDir)
+			metrics.Write(*fDataDir)
 		case <-collectTicker.C:
 			// NOTE: The value of CollectStart is used as the sample Timestamp
 			// for all metrics from a given collection. The current code relies
@@ -109,8 +107,7 @@ func main() {
 			metrics.CollectStart = time.Now()
 			metrics.Collect(client, config)
 		case <-sigterm:
-			start := metrics.IntervalStart
-			metrics.Write(start, *fDataDir)
+			metrics.Write(*fDataDir)
 			mainCancel()
 			return
 		}

--- a/disco.go
+++ b/disco.go
@@ -81,7 +81,6 @@ func main() {
 
 	writeTicker := time.NewTicker(*fWriteInterval)
 	defer writeTicker.Stop()
-	metrics.IntervalStart = time.Now()
 
 	collectTicker := time.NewTicker(10 * time.Second)
 	defer collectTicker.Stop()

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -392,7 +392,7 @@ func Test_Write(t *testing.T) {
 	archivePath := archive.GetPath(start, end, "/tmp/disco", hostname)
 	dirPath := path.Dir(archivePath)
 
-	m.Write(start, "/tmp/disco")
+	m.Write("/tmp/disco")
 	defer os.RemoveAll("/tmp/disco")
 
 	a, err := ioutil.ReadDir(dirPath)


### PR DESCRIPTION
Currently, the start time (and not long ago the end time too) in output file names is calculated based on the interval, not on the actual data contained inside the file. Most times this works, but, for example, on the first collection after the process starts, the first sample isn't recorded because there was no previous value with which to calculate a diff (which is what disco records), which meant that the filenames for the first sample interval would always be 10s before the first actual sample, causing a misalignment between the filename and what the file actually contained.

This PR follows up on #10 by also setting the filename's start time from the actual first sample timestamp contained in the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/13)
<!-- Reviewable:end -->
