### PR TITLE
Adds ifAlias label to all exported metrics.

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -200,6 +200,7 @@ func Test_New(t *testing.T) {
 			name:          "ifOutDiscards",
 			previousValue: 0,
 			scope:         "machine",
+			ifAlias:       "mlab2",
 			ifDescr:       "xe-0/0/12",
 			interval: archive.Model{
 				Experiment: "s1-abc0t.measurement-lab.org",
@@ -212,6 +213,7 @@ func Test_New(t *testing.T) {
 			name:          "ifOutDiscards",
 			previousValue: 0,
 			scope:         "uplink",
+			ifAlias:       "uplink",
 			ifDescr:       "xe-0/0/45",
 			interval: archive.Model{
 				Experiment: "s1-abc0t.measurement-lab.org",
@@ -224,6 +226,7 @@ func Test_New(t *testing.T) {
 			name:          "ifHCInOctets",
 			previousValue: 0,
 			scope:         "machine",
+			ifAlias:       "mlab2",
 			ifDescr:       "xe-0/0/12",
 			interval: archive.Model{
 				Experiment: "s1-abc0t.measurement-lab.org",
@@ -236,6 +239,7 @@ func Test_New(t *testing.T) {
 			name:          "ifHCInOctets",
 			previousValue: 0,
 			scope:         "uplink",
+			ifAlias:       "uplink",
 			ifDescr:       "xe-0/0/45",
 			interval: archive.Model{
 				Experiment: "s1-abc0t.measurement-lab.org",


### PR DESCRIPTION
It is handy to have an `ifAlias` label on all switch metrics so that we can easily query for a particular machine or the "uplink" without having to fuss with interface names (e.g., xe-0/0/12, xe-0/0/45, ge-0/0/47, etc.). `ifAlias` is currently added to all metrics collected with snmp_exporter. This PR adds an `ifAlias` label to all metrics exported by DISCOv2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/16)
<!-- Reviewable:end -->
