### PR TITLE
Sets ifAlias for uplink to actual ifAlias value on interface

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -74,7 +74,7 @@ func mustGetIfaces(client snmp.Client, machine string) map[string]map[string]str
 			ifDescrOid := createOID(ifDescrOidStub, iface)
 			oidMap, err := getOidsString(client, []string{ifDescrOid})
 			rtx.Must(err, "Failed to determine the machine interface ifDescr")
-			ifaces["machine"]["ifAlias"] = machine
+			ifaces["machine"]["ifAlias"] = val
 			ifaces["machine"]["ifDescr"] = oidMap[ifDescrOid]
 			ifaces["machine"]["iface"] = iface
 		}
@@ -82,7 +82,7 @@ func mustGetIfaces(client snmp.Client, machine string) map[string]map[string]str
 			ifDescrOid := createOID(ifDescrOidStub, iface)
 			oidMap, err := getOidsString(client, []string{ifDescrOid})
 			rtx.Must(err, "Failed to determine the uplink interface ifDescr")
-			ifaces["uplink"]["ifAlias"] = "uplink"
+			ifaces["uplink"]["ifAlias"] = val
 			ifaces["uplink"]["ifDescr"] = oidMap[ifDescrOid]
 			ifaces["uplink"]["iface"] = iface
 		}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -213,7 +213,7 @@ func Test_New(t *testing.T) {
 			name:          "ifOutDiscards",
 			previousValue: 0,
 			scope:         "uplink",
-			ifAlias:       "uplink",
+			ifAlias:       "uplink-10g",
 			ifDescr:       "xe-0/0/45",
 			interval: archive.Model{
 				Experiment: "s1-abc0t.measurement-lab.org",
@@ -239,7 +239,7 @@ func Test_New(t *testing.T) {
 			name:          "ifHCInOctets",
 			previousValue: 0,
 			scope:         "uplink",
-			ifAlias:       "uplink",
+			ifAlias:       "uplink-10g",
 			ifDescr:       "xe-0/0/45",
 			interval: archive.Model{
 				Experiment: "s1-abc0t.measurement-lab.org",


### PR DESCRIPTION
Currently, the `ifAlias` label for uplink interfaces is statically set to "uplink". However, the actual `ifAlias` on switch uplink interfaces is something like `uplink-(1|10)g`. Interfaces were labeled that way so that when being scraped Prometheus could break the value apart into two separate, useful labels `ifAlias` and `speed`. This very small PR simply sets the `ifAlias` label for uplink interfaces to be the actual value on the switch, allowing us to create a new `speed` label for all metrics in Prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/17)
<!-- Reviewable:end -->
