### PR TITLE
Collects broadcast packet metrics

### DIFF
--- a/metrics.yaml
+++ b/metrics.yaml
@@ -38,3 +38,13 @@
   oidStub: .1.3.6.1.2.1.2.2.1.19
   mlabUplinkName: switch.discards.uplink.tx
   mlabMachineName: switch.discards.local.tx
+- name: ifHCInBroadcastPkts
+  description: Ingress broadcast packets.
+  oidStub: .1.3.6.1.2.1.31.1.1.1.9
+  mlabUplinkName: switch.broadcast.uplink.rx
+  mlabMachineName: switch.broadcast.local.rx
+- name: ifHCOutBroadcastPkts
+  description: Egress broadcast packets.
+  oidStub: .1.3.6.1.2.1.31.1.1.1.13
+  mlabUplinkName: switch.broadcast.uplink.tx
+  mlabMachineName: switch.broadcast.local.tx


### PR DESCRIPTION
The original DISCOv1 used to collect both broadcast and multicast
metrics, but for some reason I chose not to collect those for DISCOv2.
Upon closer inspection, we decided that while multicast packet metrics
were indeed not necessary, that broadcast packet metrics could possibly
be useful. This commit adds collection for ingress and egress broadcast
packets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/22)
<!-- Reviewable:end -->
