### PR TITLE
Fixes an interface type conversion bug

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -69,7 +69,7 @@ func mustGetIfaces(client snmp.Client, machine string) map[string]map[string]str
 		oidParts := strings.Split(pdu.Name, ".")
 		iface := oidParts[len(oidParts)-1]
 
-		val := strings.TrimSpace(pdu.Value.(string))
+		val := strings.TrimSpace(string(pdu.Value.([]byte)))
 		if val == machine {
 			ifDescrOid := createOID(ifDescrOidStub, iface)
 			oidMap, err := getOidsString(client, []string{ifDescrOid})
@@ -113,7 +113,7 @@ func getOidsString(client snmp.Client, oids []string) (map[string]string, error)
 	oidMap := make(map[string]string)
 	result, err := client.Get(oids)
 	for _, pdu := range result.Variables {
-		oidMap[pdu.Name] = pdu.Value.(string)
+		oidMap[pdu.Name] = string(pdu.Value.([]byte))
 	}
 	return oidMap, err
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -53,12 +53,12 @@ func mustGetIfaces(client snmp.Client, machine string) map[string]map[string]str
 	rtx.Must(err, "Failed to walk the ifAlias OID")
 
 	ifaces := map[string]map[string]string{
-		"machine": map[string]string{
+		"machine": {
 			"iface":   "",
 			"ifAlias": "",
 			"ifDescr": "",
 		},
-		"uplink": map[string]string{
+		"uplink": {
 			"iface":   "",
 			"ifAlias": "",
 			"ifDescr": "",
@@ -137,7 +137,7 @@ func getOidsInt64(client snmp.Client, oids []string) (map[string]uint64, error) 
 		case uint64:
 			oidMap[pdu.Name] = value
 		default:
-			err = fmt.Errorf("Unknown type %T of SNMP type %v for OID %v", value, pdu.Type, pdu.Name)
+			err = fmt.Errorf("unknown type %T of SNMP type %v for OID %v", value, pdu.Type, pdu.Name)
 			return nil, err
 		}
 	}

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -34,14 +34,14 @@ var machine = "mlab2"
 
 var c = config.Config{
 	Metrics: []config.Metric{
-		config.Metric{
+		{
 			Name:            "ifHCInOctets",
 			Description:     "Ingress octets.",
 			OidStub:         ifHCInOctetsOidStub,
 			MlabUplinkName:  "switch.octets.uplink.rx",
 			MlabMachineName: "switch.octets.local.rx",
 		},
-		config.Metric{
+		{
 			Name:            "ifOutDiscards",
 			Description:     "Egress discards.",
 			OidStub:         ifOutDiscardsOidStub,
@@ -196,7 +196,7 @@ func Test_New(t *testing.T) {
 	m := New(s, c, target, hostname)
 
 	var expectedMetricsOIDs = map[string]*oid{
-		ifOutDiscardsMachineOID: &oid{
+		ifOutDiscardsMachineOID: {
 			name:          "ifOutDiscards",
 			previousValue: 0,
 			scope:         "machine",
@@ -209,7 +209,7 @@ func Test_New(t *testing.T) {
 				Samples:    []archive.Sample{},
 			},
 		},
-		ifOutDiscardsUplinkOID: &oid{
+		ifOutDiscardsUplinkOID: {
 			name:          "ifOutDiscards",
 			previousValue: 0,
 			scope:         "uplink",
@@ -222,7 +222,7 @@ func Test_New(t *testing.T) {
 				Samples:    []archive.Sample{},
 			},
 		},
-		ifHCInOctetsMachineOID: &oid{
+		ifHCInOctetsMachineOID: {
 			name:          "ifHCInOctets",
 			previousValue: 0,
 			scope:         "machine",
@@ -235,7 +235,7 @@ func Test_New(t *testing.T) {
 				Samples:    []archive.Sample{},
 			},
 		},
-		ifHCInOctetsUplinkOID: &oid{
+		ifHCInOctetsUplinkOID: {
 			name:          "ifHCInOctets",
 			previousValue: 0,
 			scope:         "uplink",
@@ -272,22 +272,22 @@ func Test_Collect(t *testing.T) {
 	prometheus.DefaultRegisterer = prometheus.NewRegistry()
 
 	var expectedValues = map[string]map[string]uint64{
-		ifOutDiscardsMachineOID: map[string]uint64{
+		ifOutDiscardsMachineOID: {
 			"run1Prev":   0,
 			"run2Prev":   0,
 			"run2Sample": 0,
 		},
-		ifOutDiscardsUplinkOID: map[string]uint64{
+		ifOutDiscardsUplinkOID: {
 			"run1Prev":   3,
 			"run2Prev":   8,
 			"run2Sample": 5,
 		},
-		ifHCInOctetsMachineOID: map[string]uint64{
+		ifHCInOctetsMachineOID: {
 			"run1Prev":   275,
 			"run2Prev":   511,
 			"run2Sample": 236,
 		},
-		ifHCInOctetsUplinkOID: map[string]uint64{
+		ifHCInOctetsUplinkOID: {
 			"run1Prev":   437,
 			"run2Prev":   624,
 			"run2Sample": 187,

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -56,7 +56,7 @@ var snmpPacketMachine = gosnmp.SnmpPacket{
 		{
 			Name:  ifDescrMachineOID,
 			Type:  gosnmp.OctetString,
-			Value: "xe-0/0/12",
+			Value: []byte("xe-0/0/12"),
 		},
 	},
 }
@@ -66,7 +66,7 @@ var snmpPacketUplink = gosnmp.SnmpPacket{
 		{
 			Name:  ifDescrUplinkOID,
 			Type:  gosnmp.OctetString,
-			Value: "xe-0/0/45",
+			Value: []byte("xe-0/0/45"),
 		},
 	},
 }
@@ -141,12 +141,12 @@ func (m *mockSwitchClient) BulkWalkAll(rootOid string) (results []gosnmp.SnmpPDU
 		{
 			Name:  ifDescrMachineOID,
 			Type:  gosnmp.OctetString,
-			Value: "mlab2",
+			Value: []byte("mlab2"),
 		},
 		{
 			Name:  ifDescrUplinkOID,
 			Type:  gosnmp.OctetString,
-			Value: "uplink-10g",
+			Value: []byte("uplink-10g"),
 		},
 	}, nil
 }


### PR DESCRIPTION
This upstream commit of gosnmp broke disco:

https://github.com/gosnmp/gosnmp/pull/264

This PR simply coverts the underlying byte slice to a string.

This PR also makes a few small changes to make the Go linter happier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/disco/24)
<!-- Reviewable:end -->
